### PR TITLE
Lock away funds committed in limit orders to prevent using them again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+
+This is a clone of the repository https://github.com/filipmartinsson/dex, and brings some improvements to this implementation. 
+For example funds commited to limit orders are locked away, so that users cannot use them a second time (or to withdraw them).

--- a/test/dex_lock_funds.js
+++ b/test/dex_lock_funds.js
@@ -1,0 +1,45 @@
+const Dex = artifacts.require("Dex")
+const Link = artifacts.require("Link")
+const truffleAssert = require('truffle-assertions');
+
+contract("Dex", accounts => {
+    before("Add tokens to dex", async () => {
+        let dex = await Dex.deployed()
+        let link = await Link.deployed()
+        await truffleAssert.passes(
+            dex.addToken(web3.utils.fromUtf8("LINK"), link.address, {from: accounts[0]})
+        )
+    })
+
+    //The user must have ETH deposited such that deposited eth >= buy order value
+    it("Funds allocated to limit orders should not be withdrawable by users", async () => {
+        let dex = await Dex.deployed()
+        let link = await Link.deployed()
+
+        await dex.depositEth({value: 10})
+        await truffleAssert.passes(
+            dex.createLimitOrder(0, web3.utils.fromUtf8("LINK"), 10, 1)
+        )
+        await truffleAssert.reverts(
+            dex.withdrawEth(10), null, "Expected to fail, because funds have been used on limit order."
+        )
+
+        await link.approve(dex.address, 10);
+        await dex.deposit(10, web3.utils.fromUtf8("LINK"));
+        await truffleAssert.passes(
+            dex.createLimitOrder(1, web3.utils.fromUtf8("LINK"), 10, 1)
+        )
+        await truffleAssert.reverts(
+            dex.withdraw(10, web3.utils.fromUtf8("LINK")), null, "Expected to fail, because funds have been used on limit order."
+        )
+
+        // Create market orders to empty the orderbook ... otherwise this might affect other tests :(
+        await dex.depositEth({value: 10})
+        await link.approve(dex.address, 10);
+        await dex.deposit(10, web3.utils.fromUtf8("LINK"));
+        await dex.createMarketOrder(0, web3.utils.fromUtf8("LINK"), 10);
+        await dex.createMarketOrder(1, web3.utils.fromUtf8("LINK"), 10);
+    })
+
+
+})

--- a/test/dextest.js
+++ b/test/dextest.js
@@ -2,7 +2,14 @@ const Dex = artifacts.require("Dex")
 const Link = artifacts.require("Link")
 const truffleAssert = require('truffle-assertions');
 
-contract.skip("Dex", accounts => {
+contract("Dex", accounts => {
+    before("Add tokens to dex", async () => {
+        let dex = await Dex.deployed()
+        let link = await Link.deployed()
+        await truffleAssert.passes(
+            dex.addToken(web3.utils.fromUtf8("LINK"), link.address, {from: accounts[0]})
+        )
+    })
     //The user must have ETH deposited such that deposited eth >= buy order value
     it("should throw an error if ETH balance is too low when creating BUY limit order", async () => {
         let dex = await Dex.deployed()
@@ -46,11 +53,15 @@ contract.skip("Dex", accounts => {
             assert(orderbook[i].price >= orderbook[i+1].price, "not right order in buy book")
         }
     })
+
     //The SELL order book should be ordered on price from lowest to highest starting at index 0
     it("The SELL order book should be ordered on price from lowest to highest starting at index 0", async () => {
         let dex = await Dex.deployed()
         let link = await Link.deployed()
-        await link.approve(dex.address, 500);
+
+        await link.approve(dex.address, 3);
+        await dex.deposit(3, web3.utils.fromUtf8("LINK"));
+        
         await dex.createLimitOrder(1, web3.utils.fromUtf8("LINK"), 1, 300)
         await dex.createLimitOrder(1, web3.utils.fromUtf8("LINK"), 1, 100)
         await dex.createLimitOrder(1, web3.utils.fromUtf8("LINK"), 1, 200)

--- a/test/market_order_test.js
+++ b/test/market_order_test.js
@@ -123,22 +123,22 @@ contract("Dex", accounts => {
         await dex.createLimitOrder(1, web3.utils.fromUtf8("LINK"), 1, 400, {from: accounts[2]})
 
         //Check sellers Link balances before trade
-        let account1balanceBefore = await dex.balances(accounts[1], web3.utils.fromUtf8("LINK"));
-        let account2balanceBefore = await dex.balances(accounts[2], web3.utils.fromUtf8("LINK"));
+        let account1balanceBefore = await dex.limitOrderBalances(accounts[1], web3.utils.fromUtf8("LINK"));
+        let account2balanceBefore = await dex.limitOrderBalances(accounts[2], web3.utils.fromUtf8("LINK"));
 
         //Account[0] created market order to buy up both sell orders
         await dex.createMarketOrder(0, web3.utils.fromUtf8("LINK"), 2);
 
         //Check sellers Link balances after trade
-        let account1balanceAfter = await dex.balances(accounts[1], web3.utils.fromUtf8("LINK"));
-        let account2balanceAfter = await dex.balances(accounts[2], web3.utils.fromUtf8("LINK"));
+        let account1balanceAfter = await dex.limitOrderBalances(accounts[1], web3.utils.fromUtf8("LINK"));
+        let account2balanceAfter = await dex.limitOrderBalances(accounts[2], web3.utils.fromUtf8("LINK"));
 
         assert.equal(account1balanceBefore.toNumber() - 1, account1balanceAfter.toNumber());
         assert.equal(account2balanceBefore.toNumber() - 1, account2balanceAfter.toNumber());
     })
 
     //Filled limit orders should be removed from the orderbook
-    xit("Filled limit orders should be removed from the orderbook", async () => {
+    it("Filled limit orders should be removed from the orderbook", async () => {
         let dex = await Dex.deployed()
         let link = await Link.deployed()
         await dex.addToken(web3.utils.fromUtf8("LINK"), link.address)

--- a/test/wallettest.js
+++ b/test/wallettest.js
@@ -2,7 +2,7 @@ const Dex = artifacts.require("Dex")
 const Link = artifacts.require("Link")
 const truffleAssert = require('truffle-assertions');
 
-contract.skip("Dex", accounts => {
+contract("Dex", accounts => {
     it("should only be possible for owner to add tokens", async () => {
         let dex = await Dex.deployed()
         let link = await Link.deployed()


### PR DESCRIPTION
This fixes for example the following use-case:
- the user funds the wallet
- the user creates limit orders with funds
- the user withdraws the funds
- fulfilling the market orders will fail, because the user has withdrawn the funds that should be "locked" in the contract